### PR TITLE
Fix typo in cicd/readme.md

### DIFF
--- a/cicd/readme.md
+++ b/cicd/readme.md
@@ -2,7 +2,7 @@
 
 ## Promotional Flow
 
-The promotional flow is implemented with a chain of GiHub Actions Workflows:
+The promotional flow is implemented with a chain of GitHub Actions Workflows:
 
 ![promotion-flow](../docs/images/gh-promotion-flow.png)
 


### PR DESCRIPTION
Corrected small typo: "GiHub" -> "GitHub"
(feel free to close pull request if too insignificant)